### PR TITLE
Fix: App API and freeCodeCamp URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ POST [project_url]/api/shorturl/new - body (urlencoded) :  url=https://www.googl
 
 #### Will redirect to:
 
-http://forum.freecodecamp.com
+https://www.freecodecamp.org/forum/

--- a/views/index.html
+++ b/views/index.html
@@ -26,20 +26,20 @@
         </p>
         <form action="api/shorturl/new" method="POST">
           <label for="url_input">URL to be shortened</label>
-          <input id="url_input" type="text" name="url" value="https://www.freecodecamp.com">
+          <input id="url_input" type="text" name="url" value="https://www.freecodecamp.org">
           <input type="submit" value="POST URL">
         </form>
         <h3>Example Usage:</h3>
-        <a href="https://thread-paper.hyperdev.space/api/shorturl/3">
+        <a href="https://thread-paper.glitch.me/api/shorturl/3">
           [this_project_url]/api/shorturl/3
         </a>
 
         <h3>Will Redirect to:</h3>
-        <p>https://forum.freecodecamp.com</p>
+        <p>https://www.freecodecamp.org/forum/</p>
       </div>
       <div class="footer">
         <p>
-          by <a href="http://www.freecodecamp.com">freeCodeCamp</a>
+          by <a href="https://www.freecodecamp.org">freeCodeCamp</a>
         </p>
       </div>
    </body>


### PR DESCRIPTION
This PR:
- Changes `thread-paper.hyperdev.space` to `thread-paper.glitch.me`
- Changes `forum.freecodecamp.com` to `freecodecamp.org/forum/`
- Changes `freecodecamp.com` to `freecodecamp.org`
- Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/17550
