### PR TITLE
Fixed Deprecation Warning of Mongoose - Error

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ var app = express();
 var port = process.env.PORT || 3000;
 
 /** this project needs a db !! **/ 
-// mongoose.connect(process.env.MONGOLAB_URI);
+mongoose.connect(process.env.MONGOLAB_URI, { useMongoClient: true });
 
 app.use(cors());
 


### PR DESCRIPTION
Fixed `DeprecationWarning: 'open()' is deprecated in mongoose >= 4.11.0, use 'openUri()' instead`

See: Automattic/mongoose#5399

Immediately after importing to Glitch, the app stops working and adding this object to mongoose.connect() method fixes this problem.
I think this object should already be added to the boilerplate. 😄

**Note:**  Edits from the maintainer is enabled.