### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   },
-  "engines": {
-    "node": "12.18.3"
-  },
   "license": "MIT",
   "devDependencies": {
     "nodemon": "^2.0.4"


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365