### PR TITLE
fixed public assets folder and index.html file not being sent if hosted on vercel

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const port = process.env.PORT || 3000;
 
 app.use(cors());
 
-app.use('/public', express.static(`${process.cwd()}/public`));
+app.use('/public', express.static(__dirname + "/public"));
 
 app.get('/', function(req, res) {
-  res.sendFile(process.cwd() + '/views/index.html');
+  res.sendFile( __dirname + '/views/index.html');
 });
 
 // Your first API endpoint


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

When hosting on vercel, the index.html file and the public file don't get send and return 404 even though it works locally, but with this change it would work both ways.
